### PR TITLE
Add nebulous.nvim theme to the plugin list

### DIFF
--- a/src/nvim-awesome.app/data/plugins/DilanGMB-nebulous.nvim.json
+++ b/src/nvim-awesome.app/data/plugins/DilanGMB-nebulous.nvim.json
@@ -1,0 +1,15 @@
+{
+  "name": "nebulous.nvim",
+  "description": "Minimalist Collection of Colorschemes Written in Lua",
+  "link": "https://github.com/DilanGMB/nebulous.nvim",
+  "tags": [
+    "colorscheme",
+    "treesitter",
+    "theme",
+    "lua",
+    "nvim",
+    "dark"
+  ],
+
+  "examples": []
+}


### PR DESCRIPTION
Add nebulous.nvim ( collection of colorschemes written in lua) to plugin list.
Link of the repo here:
https://github.com/DilanGMB/nebulous.nvim