### PR TITLE
Add gitlinker.nvim

### DIFF
--- a/src/nvim-awesome.app/data/plugins/ruifm-gitlinker.nvim.json
+++ b/src/nvim-awesome.app/data/plugins/ruifm-gitlinker.nvim.json
@@ -1,0 +1,16 @@
+{
+  "name": "gitlinker.nvim",
+  "description": "Lua neovim plugin to generate shareable file permalinks for git web frontend hosts",
+  "link": "https://github.com/ruifm/gitlinker.nvim",
+  "tags": [
+    "git",
+    "github",
+    "lua",
+    "lua-plugin",
+    "neovim-lua-plugin",
+    "nvim-lua",
+    "plenary",
+    "vcs"
+  ],
+  "examples": []
+}


### PR DESCRIPTION
https://github.com/ruifm/gitlinker.nvim

A lua neovim plugin to generate shareable file permalinks (with line ranges) for several git web frontend hosts. Inspired by tpope/vim-fugitive's :GBrowse 