### PR TITLE
Add nest.nvim

### DIFF
--- a/src/nvim-awesome.app/data/plugins/nest.nvim.json
+++ b/src/nvim-awesome.app/data/plugins/nest.nvim.json
@@ -1,0 +1,10 @@
+{
+  "name": "nest.nvim",
+  "description": "Lightweight utility to do concise, cascading keymaps in Lua",
+  "link": "https://github.com/LionC/nest.nvim",
+  "tags": [
+    "lua",
+    "keymap"
+  ],
+  "examples": []
+}


### PR DESCRIPTION
[nest.nvim](https://github.com/LionC/nest.nvim) is a lightweight utility plugin that allows to define keymaps in Lua using an easily readable, concise API that supports cascading options, prefixes, groupings and has sane defaults.